### PR TITLE
Add German translation

### DIFF
--- a/Languages/English/Keyed/Celsius_Keyed.xml
+++ b/Languages/English/Keyed/Celsius_Keyed.xml
@@ -44,9 +44,9 @@
 	<Celsius_MapTempOverlay_Terrain>Terrain: {0}</Celsius_MapTempOverlay_Terrain>
 	<Celsius_Terrain>Terrain</Celsius_Terrain>
 	
-	<Celsius_Stat_HeatCapacity_StuffVolumetricHeatCapacity>{0} volumetric heat capacity: {1}</Celsius_Stat_HeatCapacity_StuffVolumetricHeatCapacity>
-	<Celsius_Stat_HeatCapacity_Volume>{0} volume: {1} m^3</Celsius_Stat_HeatCapacity_Volume>
-	<Celsius_Stat_HeatCapacity_AirHeatCapacity>Air heat capacity: {0}</Celsius_Stat_HeatCapacity_AirHeatCapacity>
+	<Celsius_Stat_HeatCapacity_StuffVolumetricHeatCapacity>{0} volumetric heat capacity: {1} J/(K·m³)</Celsius_Stat_HeatCapacity_StuffVolumetricHeatCapacity>
+	<Celsius_Stat_HeatCapacity_Volume>{0} volume: {1} m³</Celsius_Stat_HeatCapacity_Volume>
+	<Celsius_Stat_HeatCapacity_AirHeatCapacity>Air heat capacity: {0} J/K</Celsius_Stat_HeatCapacity_AirHeatCapacity>
 	
 	<Celsius_Stat_HeatConductivity_BaseInsulation>{0} base insulation: {1}</Celsius_Stat_HeatConductivity_BaseInsulation>
 	<Celsius_Stat_HeatConductivity_StuffInsulation>{0} insulation: </Celsius_Stat_HeatConductivity_StuffInsulation>

--- a/Languages/German/Keyed/Celsius_Keyed.xml
+++ b/Languages/German/Keyed/Celsius_Keyed.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<LanguageData>
+	<Celsius_MountainTemperatureMode_Vanilla>Original</Celsius_MountainTemperatureMode_Vanilla>
+	<Celsius_MountainTemperatureMode_Vanilla_tooltip>Berge haben eine konstante Untergrundtemperatur (ähnlich dem Basisspiel).</Celsius_MountainTemperatureMode_Vanilla_tooltip>
+	<Celsius_MountainTemperatureMode_AnnualAverage>Jährlicher Durchschnitt</Celsius_MountainTemperatureMode_AnnualAverage>
+	<Celsius_MountainTemperatureMode_AnnualAverage_tooltip>Berge haben ganzjährig stabile Temperatur, abhängig vom Klima der Karte.</Celsius_MountainTemperatureMode_AnnualAverage_tooltip>
+	<Celsius_MountainTemperatureMode_SeasonAverage>Jahreszeitlicher Durchschnitt</Celsius_MountainTemperatureMode_SeasonAverage>
+	<Celsius_MountainTemperatureMode_SeasonAverage_tooltip>Temperatur von Bergen ändert sich langsam mit den Jahreszeiten.</Celsius_MountainTemperatureMode_SeasonAverage_tooltip>
+	<Celsius_MountainTemperatureMode_AmbientAir>Umgebungsluft</Celsius_MountainTemperatureMode_AmbientAir>
+	<Celsius_MountainTemperatureMode_AmbientAir_tooltip>Berge haben keine besonderen Einfluss auf die Temperatur; ihre Temperatur unterscheidet sich nicht von der Außentemperatur.</Celsius_MountainTemperatureMode_AmbientAir_tooltip>
+	<Celsius_MountainTemperatureMode_Manual>Manuell</Celsius_MountainTemperatureMode_Manual>
+	<Celsius_MountainTemperatureMode_Manual_tooltip>Bergtemperatur nach eigenen Vorlieben einstellen.</Celsius_MountainTemperatureMode_Manual_tooltip>
+
+	<Celsius_Settings_Vanilla>Originalfarben verwenden</Celsius_Settings_Vanilla>
+	<Celsius_Settings_Vanilla_tooltip>Farben des Basisspiels für die Wärmeanzeige statt derer von Celsius verwenden.</Celsius_Settings_Vanilla_tooltip>
+	<Celsius_Settings_ShowTempTooltip>Temperatur-Tooltip anzeigen</Celsius_Settings_ShowTempTooltip>
+	<Celsius_Settings_ShowTempTooltip_tooltip>Einen Tooltip mit de exakten Temperatur einer Zelle anzeigen, wenn die Wärmeanzeige aktiviert ist.</Celsius_Settings_ShowTempTooltip_tooltip>
+	<Celsius_Settings_FreezingAndMelting>Gefrieren und Auftauen</Celsius_Settings_FreezingAndMelting>
+	<Celsius_Settings_FreezingAndMelting_tooltip>Wasser kann gefrieren und wieder zu Wasser auftauen.</Celsius_Settings_FreezingAndMelting_tooltip>
+	<Celsius_Settings_AdvAutoignition>Fortschrittliche Selbstentzündung</Celsius_Settings_AdvAutoignition>
+	<Celsius_Settings_AdvAutoignition_tooltip>Flammbare Gegenstände können sich spontan entzünden, wenn sie zu heiß werden. Ersetzt die Selbstentzündung im Basisspiel.</Celsius_Settings_AdvAutoignition_tooltip>
+	<Celsius_Settings_PawnWeatherEffects>Wetterbedingte Effekte</Celsius_Settings_PawnWeatherEffects>
+	<Celsius_Settings_PawnWeatherEffects_tooltip>Gefühlte Temperatur (Wind) und Durchnessung beeinflussen den Wohlfühltemperaturbereich von Bewohnern.</Celsius_Settings_PawnWeatherEffects_tooltip>
+	<Celsius_Settings_TempDisplayDigits>Temperaturdezimalstellen: {0}</Celsius_Settings_TempDisplayDigits>
+	<Celsius_Settings_TempDisplayDigits_tooltip>Wie viele Dezimalstellen (Ziffern nach dem Komma) für Temperaturwerte dargestellt werden sollen. Standardwert: {0}.</Celsius_Settings_TempDisplayDigits_tooltip>
+	<Celsius_Settings_MountainTemp>Bergtemperatur:</Celsius_Settings_MountainTemp>
+	<Celsius_Settings_CurrentMapTemp_tooltip>Aktuell: {0}</Celsius_Settings_CurrentMapTemp_tooltip>
+	<Celsius_Settings_ManualTemperature>Temperatur: {0}</Celsius_Settings_ManualTemperature>
+	<Celsius_Settings_TakeOwnRisk>Ändern der nachfolgenden Werte auf eigene Gefahr!</Celsius_Settings_TakeOwnRisk>
+	<Celsius_Settings_ConductivitySpeed>Wäremeleitgeschwindigkeit: {0}</Celsius_Settings_ConductivitySpeed>
+	<Celsius_Settings_ConductivitySpeed_tooltip>Wie schnell sich die Temperatur im Laufe der Zeit ändert.</Celsius_Settings_ConductivitySpeed_tooltip>
+	<Celsius_Settings_ConvectionConductivityEffect>Konvektionsgeschwindigkeit:</Celsius_Settings_ConvectionConductivityEffect>
+	<Celsius_Settings_ConvectionConductivityEffect_tooltip>Wie stark Luftbewegungen die Wäremeleitgeschwindigkeit erhöhen. Empfohlener Wert: {0}.</Celsius_Settings_ConvectionConductivityEffect_tooltip>
+	<Celsius_Settings_EnvironmentDiffusion>Umgebungsdiffusion: {0}</Celsius_Settings_EnvironmentDiffusion>
+	<Celsius_Settings_EnvironmentDiffusion_tooltip>Wie stark die Umgebungs-/Außentemperatur die allgemeine Zellentemperatur beeinflusst. Empfohlener Wert: {0}.</Celsius_Settings_EnvironmentDiffusion_tooltip>
+	<Celsius_Settings_HeatPush>Wärmedruck: {0}</Celsius_Settings_HeatPush>
+	<Celsius_Settings_HeatPush_tooltip>Intensität mit der Objekte (zB: Feuer, Heizungen und Kühlungen) Wärme erzeugen oder reduzieren.</Celsius_Settings_HeatPush_tooltip>
+	<Celsius_Settings_DebugMode>Debug-Logging-Modus</Celsius_Settings_DebugMode>
+	<Celsius_Settings_DebugMode_tooltip>Ausfühliches Logging der Aktionen des Celsius-Mods. Voraussetzung für Fehlerberichte.</Celsius_Settings_DebugMode_tooltip>
+	<Celsius_Settings_ResetDefault>Auf Standardwerte zurücksetzen</Celsius_Settings_ResetDefault>
+	
+	<Celsius_MapTempOverlay_Cell>Zelle: {0}</Celsius_MapTempOverlay_Cell>
+	<Celsius_MapTempOverlay_Terrain>Untergrund: {0}</Celsius_MapTempOverlay_Terrain>
+	<Celsius_Terrain>Untergrund</Celsius_Terrain>
+	
+	<Celsius_Stat_HeatCapacity_StuffVolumetricHeatCapacity>Wärmespeicherzahl von {0}: {1} J/(K·m³)</Celsius_Stat_HeatCapacity_StuffVolumetricHeatCapacity>
+	<!-- Besser wäre hier: „Raumvolumen *der* Tür / *des* Sessels“ (benötigt Genitiv für eingefügte Objektnamen) -->
+	<Celsius_Stat_HeatCapacity_Volume>Raumvolumen von {0}: {1} m³</Celsius_Stat_HeatCapacity_Volume>
+	<Celsius_Stat_HeatCapacity_AirHeatCapacity>Wärmekapazität der Luft: {0} J/K</Celsius_Stat_HeatCapacity_AirHeatCapacity>
+	
+	<Celsius_Stat_HeatConductivity_BaseInsulation>Grundwert für {0}: {1}</Celsius_Stat_HeatConductivity_BaseInsulation>
+	<Celsius_Stat_HeatConductivity_StuffInsulation>{0}-Wärmedämmung: </Celsius_Stat_HeatConductivity_StuffInsulation>
+	<Celsius_Stat_HeatConductivity_AirflowOpen>{0} ist offen.</Celsius_Stat_HeatConductivity_AirflowOpen>
+	<Celsius_Stat_HeatConductivity_Airflow>Luftstrom: {0}</Celsius_Stat_HeatConductivity_Airflow>
+	<Celsius_Stat_HeatConductivity_ActualInsulation>Tatsächliche Wärmedämmung: {0}</Celsius_Stat_HeatConductivity_ActualInsulation>
+	<Celsius_Stat_HeatConductivity_Conductivity>Wärmeleitfähigkeit: {0} ^ {1} = {2}</Celsius_Stat_HeatConductivity_Conductivity>
+	
+	<Celsius_StatPart_Wetness_Explanation>Nass: {0}</Celsius_StatPart_Wetness_Explanation>
+	<Celsius_StatPart_WindSpeed_Explanation>Wind x{0}: {1}</Celsius_StatPart_WindSpeed_Explanation>
+
+</LanguageData>


### PR DESCRIPTION
Missing some critical bits that are hard-coded / not exposed as Keyed attributes (incomplete internationalization). I also added some extra temperature units were they make sense and used `³` instead of `^3`. Spent some time yesterday on reading up on thermodynamics terms used, so I’m pretty confident I got the german jargon terms correct now (got some them wrong at first of course :slightly_smiling_face:).