### PR TITLE
Update German translation for Celsius 2.2 / latest changes

### DIFF
--- a/Languages/English/Keyed/Celsius_Keyed.xml
+++ b/Languages/English/Keyed/Celsius_Keyed.xml
@@ -45,7 +45,17 @@
 	<Celsius_MapTempOverlay_Cell>Cell: {0}</Celsius_MapTempOverlay_Cell>
 	<Celsius_MapTempOverlay_Terrain>Terrain: {0}</Celsius_MapTempOverlay_Terrain>
 	<Celsius_Terrain>Terrain</Celsius_Terrain>
-	
+
+	<!-- Translator hints:
+	Since the thermodynamics system implemented in Celsius is a simplification
+	of the one implemented in the universe containing Earth most of the
+	following stats are presented without use of SI units. The units most
+	similar to those on Earth are listed below for making it easier for
+	translators to figure out the most suitable thermal engineering vocabulary
+	in their languages however:
+	 * Volumetric heat capacity: J/(K·m³)
+	 * Air heat capacity: J/K
+	-->
 	<Celsius_Stat_HeatCapacity_StuffVolumetricHeatCapacity>{0} volumetric heat capacity: {1}/m³</Celsius_Stat_HeatCapacity_StuffVolumetricHeatCapacity>
 	<Celsius_Stat_HeatCapacity_Volume>{0} volume: {1} m³</Celsius_Stat_HeatCapacity_Volume>
 	<Celsius_Stat_HeatCapacity_AirHeatCapacity>Air heat capacity: {0}</Celsius_Stat_HeatCapacity_AirHeatCapacity>

--- a/Languages/German/Keyed/Celsius_Keyed.xml
+++ b/Languages/German/Keyed/Celsius_Keyed.xml
@@ -28,10 +28,14 @@
 	<Celsius_Settings_CurrentMapTemp_tooltip>Aktuell: {0}</Celsius_Settings_CurrentMapTemp_tooltip>
 	<Celsius_Settings_ManualTemperature>Temperatur: {0}</Celsius_Settings_ManualTemperature>
 	<Celsius_Settings_TakeOwnRisk>Ändern der nachfolgenden Werte auf eigene Gefahr!</Celsius_Settings_TakeOwnRisk>
+	<Celsius_Settings_UpdateInterval>Aktualisierungsrate: {0} Ticks</Celsius_Settings_UpdateInterval>
+	<Celsius_Settings_UpdateInterval_tooltip>Häufigkeit mit der die Temperaturwerte auf der Karte aktualisiert werden. Niedrigere Werte erhöhen die Genauigkeit, höhere Werte reduzieren die benötigte Rechenleistung. 1 Sekunde = 60 Ticks bei normaler Spielgeschwindigkeit. Empfohlener Wert: {0} Ticks.</Celsius_Settings_UpdateInterval_tooltip>
 	<Celsius_Settings_ConvectionConductivityEffect>Konvektionsgeschwindigkeit:</Celsius_Settings_ConvectionConductivityEffect>
 	<Celsius_Settings_ConvectionConductivityEffect_tooltip>Wie stark Luftbewegungen die Wäremeleitgeschwindigkeit erhöhen. Empfohlener Wert: {0}.</Celsius_Settings_ConvectionConductivityEffect_tooltip>
 	<Celsius_Settings_EnvironmentDiffusion>Umgebungsdiffusion: {0}</Celsius_Settings_EnvironmentDiffusion>
 	<Celsius_Settings_EnvironmentDiffusion_tooltip>Wie stark die Umgebungs-/Außentemperatur die allgemeine Zellentemperatur beeinflusst. Empfohlener Wert: {0}.</Celsius_Settings_EnvironmentDiffusion_tooltip>
+	<Celsius_Settings_RoofInsulation>Dachisolierung: {0}</Celsius_Settings_RoofInsulation>
+	<Celsius_Settings_RoofInsulation_tooltip>Stärke mit der Dächer (ob durch Bewohner gebaut oder bereits vorhanden) die Innentemperatur in Räumen erhalten. Empfohlener Wert: {0}.</Celsius_Settings_RoofInsulation_tooltip>
 	<Celsius_Settings_HeatPush>Wärmedruck: {0}</Celsius_Settings_HeatPush>
 	<Celsius_Settings_HeatPush_tooltip>Intensität mit der Objekte (zB: Feuer, Heizungen und Kühlungen) Wärme erzeugen oder reduzieren.</Celsius_Settings_HeatPush_tooltip>
 	<Celsius_Settings_DebugMode>Debug-Logging-Modus</Celsius_Settings_DebugMode>
@@ -54,5 +58,6 @@
 	
 	<Celsius_StatPart_Wetness_Explanation>Nass: {0}</Celsius_StatPart_Wetness_Explanation>
 	<Celsius_StatPart_WindSpeed_Explanation>Wind x{0}: {1}</Celsius_StatPart_WindSpeed_Explanation>
+	<Celsius_StatPart_DirectSunlight_Explanation>In der Sonne: {0}</Celsius_StatPart_DirectSunlight_Explanation>
 
 </LanguageData>


### PR DESCRIPTION
Follow-up for #35 – I’m just not that fast with responding, but no biggy. :slightly_smiling_face: 

> And can you let me know which parts are not exposed as attributes? I might have missed a few lines, but it wasn't the intention.

I checked for the missing strings again today and realized they are all &lt;label&gt; and &lt;description&gt; values from `1.4/Defs/*/*.xml` (but the first character is upper-cased in the UI, so that’s why `ag` – and hence me – didn’t find them before). Is there some way I can translate these using just XML or do you need to do any changes to make that possible first?